### PR TITLE
feat: allow definition of plugins

### DIFF
--- a/docs/api/options/ajv.md
+++ b/docs/api/options/ajv.md
@@ -187,20 +187,22 @@ export default {
 
 ### Extend Ajv instance
 
-Note that this is neither tested nor supported but in theory this would give extra Ajv features such as [ajv-async](https://github.com/epoberezkin/ajv-async) and [ajv-merge-patch](https://github.com/epoberezkin/ajv-merge-patch) access to the internal `Ajv` instance running inside `vue-form-json-schema`
+Note that this is neither tested nor supported but in theory this would give extra Ajv features such as [ajv-async](https://github.com/epoberezkin/ajv-async) and [ajv-merge-patch](https://github.com/epoberezkin/ajv-merge-patch) access to the internal `Ajv` instance running inside `vue-form-json-schema`.
+
+By adding the required plugin to the `plugins` section in the ajv options it is possible to load and apply the required plugin to the ajv instance that is used by `vue-form-json-schema`. This comes in handy when custom error messages must be added with [ajv-errors](https://github.com/epoberezkin/ajv-errors).
 
 ```js
 // Import swedish localization
-const sv = require('ajv-i18n/localize/sv');
+const ajvErrors = require('ajv-errors');
 
 export default {
   data() {
     return {
       options: {
         ajv: {
-          options: {
+          plugins: {
+            ajvErrors: ajvErrors
           }
-          locale: sv
         }
       },
       model: {

--- a/src/vfjs-global-mixin/methods/vfjs-validation/index.js
+++ b/src/vfjs-global-mixin/methods/vfjs-validation/index.js
@@ -6,7 +6,7 @@ import { VFJS_EVENT_MODEL_VALIDATE } from '../../../constants';
 const vfjsValidation = {
   vfjsValidationInitialize() {
     const { ajv = {} } = this.vfjsOptions;
-    const { options = {}, keywords = {} } = ajv;
+    const { options = {}, keywords = {}, plugins = {} } = ajv;
 
     // Set up Ajv
     this.ajv = new Ajv({
@@ -17,9 +17,9 @@ const vfjsValidation = {
 
     // Allow Ajv to be extended by other functions
     // such as ajv-merge-patch, ajv-async etc.
-    Object.keys(keywords).forEach((key) => {
-      if (typeof keywords[key] === 'function') {
-        keywords[key](this.ajv);
+    Object.keys(plugins).forEach((name) => {
+      if (typeof plugins[name] === 'function') {
+        plugins[name](this.ajv);
       }
     });
 


### PR DESCRIPTION
Hi Tobias, I want to add ajv plugins to the ajv instance used by vue-form-json-schema. You have already laid out the foundation in your code but it is not possible to add a plugin within the keywords section, since ajv would complain about the keyword not being an object. Instead I added a new options key `plugins` where the developer can decide which plugins to use. The plugins given in that section will then be attached to the ajv instance as intended by your initial approach. It would be great, if you could merge this change into your master branch, since we "urgently" need that feature to work.

I really love what you have done so far, keep up the good work!