### PR TITLE
Enable 'oneOf' - validation

### DIFF
--- a/src/vfjs-global-mixin/methods/vfjs-schema/getters.js
+++ b/src/vfjs-global-mixin/methods/vfjs-schema/getters.js
@@ -36,6 +36,13 @@ const vfjsSchemaGetters = {
 
         const arrayPath = this.getVfjsSchemaPath(`${path}.items`);
         return this.getVfjsSchemaPath(`${arrayPath}.0`);
+      } else if (schema.oneOf instanceof Array) {
+        const index = schema.oneOf.findIndex(
+          optionSchema => (
+            optionSchema.properties instanceof Object && Object.keys(optionSchema.properties).includes(key)
+          ),
+        );
+        return this.getVfjsSchemaPath(`${path}.oneOf.${index}`, key);
       } else if (schema.properties instanceof Object) {
         return this.getVfjsSchemaPath(`${path}.properties`, key);
       }


### PR DESCRIPTION
Hi @jarvelov!

It's me again :) 

I found out that the 'oneOf' can't be handled correctly right now. The reason for that is that it's missing in the schema retrieval via the `getVfjsSchemaPath` method. This results in all fields below a oneOf to not be validated at all. 

Therefore, here's a small suggestion on how we could implement that.

If you want to see an example, check this out (choose 'oneOf')
[React JsonSchema](https://rjsf-team.github.io/react-jsonschema-form/)

Hope this helps!