### PR TITLE
Fix for different notations of error.dataPath

### DIFF
--- a/src/vfjs-global-mixin/methods/vfjs-validation/getters.js
+++ b/src/vfjs-global-mixin/methods/vfjs-validation/getters.js
@@ -18,7 +18,27 @@ const vfjsValidationGetters = {
       if (error.keyword === 'required') {
         if (error.params && error.params.missingProperty) {
           const key = error.params.missingProperty;
-          const parent = String(error.dataPath).substr(1).replace(/\//g, '.');
+          
+          const errorDataPathPrefix = String(error.dataPath).substr(0, 1);
+          let parent;
+          
+          switch (errorDataPathPrefix) {
+            // JSONpath dot notation
+            case '.':
+              parent = error.dataPath.substr(1);
+              break;
+              
+            // JSONpath bracket notation
+            case '[':
+              parent = error.dataPath.substr(2, error.dataPath.length - 4).replace('\'][\'', '.');
+              break;
+              
+            // JSONpointer notation with forward slashes
+            case '/':
+              parent = error.dataPath.substr(1).replace(/\//g, '.');
+              break;
+          }
+          
           const propertyPath = parent ? `${parent}.${key}` : key;
 
           if (required.indexOf(propertyPath) === -1) {


### PR DESCRIPTION
Second try .. please feel free to adapt it.

Due to the use of lodash's get/set it seems that one important constraint regarding form property names still remains:

*Dots are not allowed in form property names when the nested property feature of VFJS is used.*

Once the Ajv version is upgraded, error.dataPath would always contain JSON Pointer notation. 

As a consequence this fix could be reduced to the third option of the switch statement.
