### PR TITLE
Fix prop type validation for fieldOptions.valueModel

### DIFF
--- a/src/vfjs-field-mixin/props.js
+++ b/src/vfjs-field-mixin/props.js
@@ -75,7 +75,7 @@ const props = {
     type: null,
   },
   vfjsFieldValueModelKey: {
-    type: String,
+    type: [String, Boolean],
   },
   vfjsOptions: {
     type: Object,


### PR DESCRIPTION
Hi, in the [documentation on field/valueModel](https://jarvelov.gitbook.io/vue-form-json-schema/api/vue-form-json-schema/ui-schema/field/value-model) it says:

> You can also use valueModel: true to pass the entire form model to the field.

I think the prop types need to be extended for this to actually work (allowing Boolean).
Otherwise I get an error message about an illegal prop type.