### PR TITLE
fix: Using the lodash set function was causing an error when the path ended in a number.

### DIFF
--- a/src/vfjs-global-mixin/methods/vfjs-validation/getters.js
+++ b/src/vfjs-global-mixin/methods/vfjs-validation/getters.js
@@ -1,4 +1,4 @@
-import { set } from 'lodash';
+import { set, setWith } from 'lodash';
 
 const vfjsValidationGetters = {
   /** getVfjsPropertiesRequired
@@ -122,7 +122,7 @@ const vfjsValidationGetters = {
       const required = previousPaths.length > 0 ? `${previousProperties}.required` : 'required';
 
       if (index === paths.length - 1) {
-        set(schema, properties, fieldSchema);
+        setWith(schema, properties, fieldSchema, Object);
 
         if (isRequired) {
           set(schema, required, [path]);


### PR DESCRIPTION
Using the lodash set function was causing an error when the path
 ended in a number. This is because the previous specified object in the path was set as an array. The lodash setWith function allows specifying everything to be set as an object.